### PR TITLE
Fixed sizing of the carousel gradients

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -649,17 +649,22 @@ a.button:focus {
   top: 0;
   bottom: 0;
   pointer-events: none;
+
+  /* Match the size of the smaller cells on the outside of the carousel */
+  -webkit-transform: scale(0.9);
+  -ms-transform: scale(0.9);
+  transform: scale(0.9);
 }
 
 .flickity-viewport:before {
-  left: -3px;
+  left: -13px;
   background-image: -webkit-gradient(linear, left top, right top, from(var(--color-background)), to(rgba(255, 255, 255, 0)));
   background-image: -o-linear-gradient(left, var(--color-background), rgba(255, 255, 255, 0));
   background-image: linear-gradient(to right, var(--color-background), rgba(255, 255, 255, 0));
 }
 
 .flickity-viewport:after {
-  right: -3px;
+  right: -13px;
   background-image: -webkit-gradient(linear, right top, left top, from(var(--color-background)), to(rgba(255, 255, 255, 0)));
   background-image: -o-linear-gradient(right, var(--color-background), rgba(255, 255, 255, 0));
   background-image: linear-gradient(to left, var(--color-background), rgba(255, 255, 255, 0));


### PR DESCRIPTION
Fixes an issue where the carousel gradients are taller than the carousel slides:

Live Site:
![image](https://user-images.githubusercontent.com/6632788/155759278-d8c90094-a29b-4445-b5cd-91904b32c2f5.png)


Fix:
![image](https://user-images.githubusercontent.com/6632788/155759204-06317d67-8c7a-4957-be30-cfb2b2d70cca.png)
