### PR TITLE
Added shortlinks for the updated invite email

### DIFF
--- a/android-app.html
+++ b/android-app.html
@@ -1,0 +1,12 @@
+<!-- Redirects hackers to install the Bitcamp Android App -->
+
+<!-- TODO: replace with link to our actual mobile app -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="Refresh" content="0; url=https://play.google.com/store" />
+</head>
+
+</html>

--- a/ios-app.html
+++ b/ios-app.html
@@ -1,0 +1,12 @@
+<!-- Redirects hackers to install the Bitcamp iOS App -->
+
+<!-- TODO: replace with link to our actual mobile app -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="Refresh" content="0; url=https://www.apple.com/app-store/" />
+</head>
+
+</html>

--- a/slack-invite.html
+++ b/slack-invite.html
@@ -1,0 +1,12 @@
+<!-- Redirects hackers to the Bitcamp 2022 Slack invite -->
+
+<!-- TODO: replace with an invite from a more official-looking account -->
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="Refresh" content="0; url=https://bitcamp2022.slack.com/join/shared_invite/zt-15q4wm1xh-KyxaiEU2heqYjjKAdX77nw" />
+</head>
+
+</html>

--- a/slack-invite.html
+++ b/slack-invite.html
@@ -6,7 +6,7 @@
 <html>
 
 <head>
-  <meta http-equiv="Refresh" content="0; url=https://bitcamp2022.slack.com/join/shared_invite/zt-15q4wm1xh-KyxaiEU2heqYjjKAdX77nw" />
+  <meta http-equiv="Refresh" content="0; url=https://join.slack.com/t/bitcamp2022/shared_invite/zt-15qfwwgf9-OZCGD5~Jxn3OwY0wlJ~ROw" />
 </head>
 
 </html>


### PR DESCRIPTION
The new invite email template links to a slack invite, the ios app, and the android app. Instead of linking directly to the pages in the email, we setup shortlinks so that they can be easily changed without modifying the email template.